### PR TITLE
Fix import of Discrete2DMesh from raysect

### DIFF
--- a/cherab/solps/formats/mdsplus.py
+++ b/cherab/solps/formats/mdsplus.py
@@ -21,7 +21,7 @@ import re
 import numpy as np
 from math import sqrt
 from raysect.core import Point2D
-from raysect.core.math.interpolators import Discrete2DMesh
+from raysect.core.math.function import Discrete2DMesh
 
 from cherab.core.math.mappers import AxisymmetricMapper
 from cherab.solps.mesh_geometry import SOLPSMesh

--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -19,7 +19,7 @@
 
 import os
 import numpy as np
-from raysect.core.math.interpolators import Discrete2DMesh
+from raysect.core.math.function import Discrete2DMesh
 
 from cherab.core.math.mappers import AxisymmetricMapper
 from cherab.core.atomic.elements import hydrogen, deuterium, helium, beryllium, carbon, nitrogen, oxygen, neon, \

--- a/cherab/solps/mesh_geometry.py
+++ b/cherab/solps/mesh_geometry.py
@@ -24,7 +24,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
-from raysect.core.math.interpolators import Discrete2DMesh
+from raysect.core.math.function import Discrete2DMesh
 
 INFINITY = 1E99
 

--- a/cherab/solps/solps_3d_functions.pyx
+++ b/cherab/solps/solps_3d_functions.pyx
@@ -23,11 +23,10 @@ import numpy as np
 from numpy cimport ndarray
 
 from raysect.core.math.vector cimport Vector3D, new_vector3d
-from raysect.core.math.interpolators cimport Discrete2DMesh
-from raysect.core.math.transform import rotate_z
+from raysect.core.math.function cimport Discrete2DMesh, Function3D
+from raysect.core.math.transform cimport rotate_z
 
 from cherab.core.math.mappers cimport AxisymmetricMapper
-from cherab.core.math.function cimport Function3D
 from cherab.core.math.function.vectorfunction3d cimport VectorFunction3D
 cimport cython
 

--- a/cherab/solps/solps_plasma.py
+++ b/cherab/solps/solps_plasma.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 from scipy.constants import atomic_mass, electron_mass
 
 # Raysect imports
-from raysect.core.math.interpolators import Discrete2DMesh
+from raysect.core.math.function import Discrete2DMesh
 from raysect.core import translate, Point3D, Vector3D, Node, AffineMatrix3D
 from raysect.primitive import Cylinder
 from raysect.optical import Spectrum


### PR DESCRIPTION
Raysect 0.6 moves this import to raysect.core.math.function.