### PR TITLE
Fix check for DAB2 being present in MDSplus.

### DIFF
--- a/cherab/solps/formats/mdsplus.py
+++ b/cherab/solps/formats/mdsplus.py
@@ -93,9 +93,9 @@ def load_solps_from_mdsplus(mds_server, ref_number):
     sim._radial_area = np.swapaxes(conn.get('\SOLPS::TOP.SNAPSHOT.SY').data(), 0, 1)  # radial contact area
 
     # Load the neutral atom density from B2
-    dab2 = conn.get('\SOLPS::TOP.SNAPSHOT.DAB2')
+    dab2 = conn.get('\SOLPS::TOP.SNAPSHOT.DAB2').data()
     if isinstance(dab2, np.ndarray):
-        sim._b2_neutral_densities = np.swapaxes(dab2.data(), 0, 2)
+        sim._b2_neutral_densities = np.swapaxes(dab2, 0, 2)
 
     sim._velocities_parallel = np.swapaxes(conn.get('\SOLPS::TOP.SNAPSHOT.UA').data(), 0, 2)
     sim._velocities_radial = np.zeros((ni, nj, len(sim.species_list)))
@@ -112,7 +112,7 @@ def load_solps_from_mdsplus(mds_server, ref_number):
         charge = int(charge)
 
         # If neutral and B" atomic density available,  use B2 density, otherwise use fluid species density.
-        if charge == 0 and (sim._b2_neutral_densities != None):
+        if charge == 0 and (sim._b2_neutral_densities is not None):
             species_dens_data = sim.b2_neutral_densities[:, :, b2_neutral_i]
             b2_neutral_i += 1
         else:


### PR DESCRIPTION
MDSplus read returns a Signal object, not an array. Fixes #26.