### PR TITLE
Fort44 parser for pre 2007 Eirene fort.44 file versions

### DIFF
--- a/cherab/solps/eirene/parser/fort44.py
+++ b/cherab/solps/eirene/parser/fort44.py
@@ -18,7 +18,7 @@
 
 from cherab.solps.eirene.parser.fort44_2017 import load_fort44_2017
 from cherab.solps.eirene.parser.fort44_2013 import load_fort44_2013
-from cherab.solps.eirene.parser.fort44_old import load_fort44_old
+from cherab.solps.eirene.parser.fort44_pre_2007 import load_fort44_pre_2007
 
 
 def load_fort44_file(file_path, debug=False):
@@ -59,18 +59,22 @@ def assign_fort44_parser(file_version):
     :return: Parsing function object
     """
 
+    # TODO write universal fort44 parser
+
+    # Parser load_fort44_pre_2007 is used also for 20071209, 20080706 and 20081111
+    # versions as a temporary solution. Parameter 'eneutrad' is not parsed from these file versions.
     fort44_parser_library = {
-        960511: load_fort44_old,
-        960513: load_fort44_old,
-        960623: load_fort44_old,
-        960727: load_fort44_old,
-        961228: load_fort44_old,
-        20000727: load_fort44_old,
-        20051115: load_fort44_old,
-        20060206: load_fort44_old,
-        20071209: load_fort44_old,  # here we are missing eneutrad
-        20080706: load_fort44_old,  # here we are missing eneutrad
-        20081111: load_fort44_old,  # here we are missing eneutrad
+        960511: load_fort44_pre_2007,
+        960513: load_fort44_pre_2007,
+        960623: load_fort44_pre_2007,
+        960727: load_fort44_pre_2007,
+        961228: load_fort44_pre_2007,
+        20000727: load_fort44_pre_2007,
+        20051115: load_fort44_pre_2007,
+        20060206: load_fort44_pre_2007,
+        20071209: load_fort44_pre_2007,
+        20080706: load_fort44_pre_2007,
+        20081111: load_fort44_pre_2007,
         20130210: load_fort44_2013,
         20170328: load_fort44_2017
     }

--- a/cherab/solps/eirene/parser/fort44.py
+++ b/cherab/solps/eirene/parser/fort44.py
@@ -18,6 +18,7 @@
 
 from cherab.solps.eirene.parser.fort44_2017 import load_fort44_2017
 from cherab.solps.eirene.parser.fort44_2013 import load_fort44_2013
+from cherab.solps.eirene.parser.fort44_old import load_fort44_old
 
 
 def load_fort44_file(file_path, debug=False):
@@ -59,8 +60,19 @@ def assign_fort44_parser(file_version):
     """
 
     fort44_parser_library = {
-        20170328: load_fort44_2017,
-        20130210: load_fort44_2013
+        960511: load_fort44_old,
+        960513: load_fort44_old,
+        960623: load_fort44_old,
+        960727: load_fort44_old,
+        961228: load_fort44_old,
+        20000727: load_fort44_old,
+        20051115: load_fort44_old,
+        20060206: load_fort44_old,
+        20071209: load_fort44_old,  # here we are missing eneutrad
+        20080706: load_fort44_old,  # here we are missing eneutrad
+        20081111: load_fort44_old,  # here we are missing eneutrad
+        20130210: load_fort44_2013,
+        20170328: load_fort44_2017
     }
 
     if file_version in fort44_parser_library.keys():

--- a/cherab/solps/eirene/parser/fort44_old.py
+++ b/cherab/solps/eirene/parser/fort44_old.py
@@ -1,0 +1,105 @@
+# Copyright 2016-2018 Euratom
+# Copyright 2016-2018 United Kingdom Atomic Energy Authority
+# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from cherab.solps.eirene import Eirene
+from cherab.solps.eirene.parser.utility import read_block44
+
+
+def load_fort44_old(file_path, debug=False):
+    """ Read neutral species and wall flux information from fort.44
+
+    Template for reading is ngread.F in b2plot of B2.5 source.
+    This is for fort.44 files with format ID < 20071209.
+
+    :param str file_path: path to the fort.44 file
+    :param bool debug: status flag for printing debugging output
+    :rtype:
+    """
+
+    with open(file_path, 'r') as file_handle:
+        # Read sizes
+        line = file_handle.readline().split()
+        nx = int(line[0])
+        ny = int(line[1])
+        version = int(line[2])
+        if debug:
+            print('Geometry & Version : nx {}, ny {}, version {}'
+                  .format(nx, ny, version))
+
+        # Read Species numbers
+        line = file_handle.readline().split()
+        na = int(line[0])  # number of atoms
+        nm = int(line[1])  # number of molecules
+        ni = int(line[2])  # number of ions
+        ns = na + nm + ni  # total number of species
+        if debug:
+            print('Species # : {} atoms, {} molecules, {} ions, {} total species'
+                  .format(na, nm, ni, ns))
+
+        # Read Species labels
+        species_labels = []
+        for _ in range(ns):
+            line = file_handle.readline()
+            species_labels.append(line.strip())
+        if debug:
+            print("Species labels => {}".format(species_labels))
+
+        # create eirene object
+        eirene = Eirene(nx, ny, na, nm, ni, ns, species_labels, version)
+
+        # Read atomic species (da, ta)
+        eirene.da = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Neutral Density
+        eirene.ta = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Neutral Temperature
+        if debug:
+            print('Atomic Neutral Density nD0: ', eirene.da[0, :, 0])
+            print('Atomic Neutral Temperature TD0: ', eirene.ta[0, :, 0])
+
+        # Read molecular species (dm, tm)
+        eirene.dm = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Neutral Density
+        eirene.tm = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Neutral Temperature
+
+        # Read ion species (di, ti)
+        eirene.di = read_block44(file_handle, eirene.ni, nx, ny)  # Test Ion Density
+        eirene.ti = read_block44(file_handle, eirene.ni, nx, ny)  # Test Ion Temperature
+
+        # Read radial particle flux (rpa, rpm)
+        eirene.rpa = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Radial Particle Flux
+        eirene.rpm = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Radial Particle Flux
+
+        # Read poloidal particle flux (ppa, ppm)
+        eirene.ppa = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Poloidal Particle Flux
+        eirene.ppm = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Poloidal Particle Flux
+
+        # Read radial energy flux (rea, rem)
+        eirene.rea = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Radial Energy Flux
+        eirene.rem = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Radial Energy Flux
+
+        # Read poloidal energy flux (pea, pem)
+        eirene.pea = read_block44(file_handle, eirene.na, nx, ny)  # Atomic Poloidal Energy Flux
+        eirene.pem = read_block44(file_handle, eirene.nm, nx, ny)  # Molecular Poloidal Energy Flux
+
+        # Halpha total & molecules (emist, emism)
+        eirene.emist = read_block44(file_handle, 1, nx, ny)  # Total Halpha Emission (including molecules)
+        eirene.emism = read_block44(file_handle, 1, nx, ny)  # Molecular Halpha Emission
+
+        if version >= 960511:
+            # Radiated power (elosm, edism)
+            eirene.elosm = read_block44(file_handle, nm, nx, ny)  # Power loss due to molecules (including dissociation)
+            eirene.edism = read_block44(file_handle, nm, nx, ny)  # Power loss due to molecule dissociation
+
+    return eirene

--- a/cherab/solps/eirene/parser/fort44_pre_2007.py
+++ b/cherab/solps/eirene/parser/fort44_pre_2007.py
@@ -20,7 +20,7 @@ from cherab.solps.eirene import Eirene
 from cherab.solps.eirene.parser.utility import read_block44
 
 
-def load_fort44_old(file_path, debug=False):
+def load_fort44_pre_2007(file_path, debug=False):
     """ Read neutral species and wall flux information from fort.44
 
     Template for reading is ngread.F in b2plot of B2.5 source.


### PR DESCRIPTION
This adds a fort.44 parser for the Eirene fort.44 file versions older than 20071209. This parser does not read total radiated power by neutral atoms ('eneutrad'), which was introduced in version 20071209. It is suggested to use this parser also for versions 20071209. 20080706 and 20081111 as a workaround until a generic parser is created. See discussion in #32 and #39.