### PR TITLE
Fix deprecation and syntax warnings in recent Python and Numpy

### DIFF
--- a/cherab/solps/formats/balance.py
+++ b/cherab/solps/formats/balance.py
@@ -45,8 +45,8 @@ def load_solps_from_balance(balance_filename):
 
         species_list = []
         neutral_indx = []
-        am = np.round(fhandle.variables['am'].data).astype(np.int)  # Atomic mass number
-        charge = fhandle.variables['za'].data.astype(np.int)   # Ionisation/charge
+        am = np.round(fhandle.variables['am'].data).astype(int)  # Atomic mass number
+        charge = fhandle.variables['za'].data.astype(int)   # Ionisation/charge
         species_names = fhandle.variables['species'].data.copy()
         ns = am.size
         for i in range(ns):
@@ -94,7 +94,7 @@ def load_solps_from_balance(balance_filename):
             for key in fhandle.variables.keys():
                 if 'fna_' in key:
                     fna += fhandle.variables[key].data.copy()
-            if fna is not 0:
+            if np.any(fna != 0):
                 # Obtaining velocity from B2 flux
                 sim.velocities_cylindrical = b2_flux_to_velocity(sim, fna[:, 0], fna[:, 1], parallel_velocity)
 
@@ -164,7 +164,7 @@ def load_solps_from_balance(balance_filename):
             # Save total radiated power to the simulation object
             total_rad = rydberg_energy * el_charge * potential_loss - b2_ploss
 
-        if total_rad is not 0:
+        if np.any(total_rad != 0):
             sim.total_radiation = total_rad
 
     return sim
@@ -179,18 +179,18 @@ def load_mesh_from_netcdf(fhandle):
     vol = fhandle.variables['vol'].data.copy()
 
     # Loading neighbouring cell indices
-    neighbix = np.zeros(r.shape, dtype=np.int)
-    neighbiy = np.zeros(r.shape, dtype=np.int)
+    neighbix = np.zeros(r.shape, dtype=int)
+    neighbiy = np.zeros(r.shape, dtype=int)
 
-    neighbix[0] = fhandle.variables['leftix'].data.astype(np.int)  # poloidal prev.
-    neighbix[1] = fhandle.variables['bottomix'].data.astype(np.int)  # radial prev.
-    neighbix[2] = fhandle.variables['rightix'].data.astype(np.int)  # poloidal next
-    neighbix[3] = fhandle.variables['topix'].data.astype(np.int)  # radial next
+    neighbix[0] = fhandle.variables['leftix'].data.astype(int)  # poloidal prev.
+    neighbix[1] = fhandle.variables['bottomix'].data.astype(int)  # radial prev.
+    neighbix[2] = fhandle.variables['rightix'].data.astype(int)  # poloidal next
+    neighbix[3] = fhandle.variables['topix'].data.astype(int)  # radial next
 
-    neighbiy[0] = fhandle.variables['leftiy'].data.astype(np.int)
-    neighbiy[1] = fhandle.variables['bottomiy'].data.astype(np.int)
-    neighbiy[2] = fhandle.variables['rightiy'].data.astype(np.int)
-    neighbiy[3] = fhandle.variables['topiy'].data.astype(np.int)
+    neighbiy[0] = fhandle.variables['leftiy'].data.astype(int)
+    neighbiy[1] = fhandle.variables['bottomiy'].data.astype(int)
+    neighbiy[2] = fhandle.variables['rightiy'].data.astype(int)
+    neighbiy[3] = fhandle.variables['topiy'].data.astype(int)
 
     # In SOLPS cell indexing starts with -1 (guarding cell), but in SOLPSMesh -1 means no neighbour.
     neighbix += 1

--- a/cherab/solps/formats/mdsplus.py
+++ b/cherab/solps/formats/mdsplus.py
@@ -44,9 +44,9 @@ def load_solps_from_mdsplus(mds_server, ref_number):
 
     # Load each plasma species in simulation
     ns = conn.get(r'\SOLPS::TOP.IDENT.NS').data()  # Number of species
-    zn = conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.ZN').data().astype(np.int)  # Nuclear charge
-    am = np.round(conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.AM').data()).astype(np.int)  # Atomic mass number
-    charge = conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.ZA').data().astype(np.int)   # Ionisation/charge
+    zn = conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.ZN').data().astype(int)  # Nuclear charge
+    am = np.round(conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.AM').data()).astype(int)  # Atomic mass number
+    charge = conn.get(r'\SOLPS::TOP.SNAPSHOT.GRID.ZA').data().astype(int)   # Ionisation/charge
 
     species_list = []
     neutral_indx = []
@@ -155,7 +155,7 @@ def load_solps_from_mdsplus(mds_server, ref_number):
 
     total_rad = linerad + brmrad + neurad
 
-    if total_rad is not 0:
+    if np.any(total_rad != 0):
         sim.total_radiation = total_rad / mesh.vol
 
     return sim
@@ -176,18 +176,18 @@ def load_mesh_from_mdsplus(mds_connection, MdsException):
     vol = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.VOL').data()
 
     # Loading neighbouring cell indices
-    neighbix = np.zeros(r.shape, dtype=np.int)
-    neighbiy = np.zeros(r.shape, dtype=np.int)
+    neighbix = np.zeros(r.shape, dtype=int)
+    neighbiy = np.zeros(r.shape, dtype=int)
 
-    neighbix[0] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:LEFTIX').data().astype(np.int)
-    neighbix[1] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:BOTTOMIX').data().astype(np.int)
-    neighbix[2] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:RIGHTIX').data().astype(np.int)
-    neighbix[3] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:TOPIX').data().astype(np.int)
+    neighbix[0] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:LEFTIX').data().astype(int)
+    neighbix[1] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:BOTTOMIX').data().astype(int)
+    neighbix[2] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:RIGHTIX').data().astype(int)
+    neighbix[3] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:TOPIX').data().astype(int)
 
-    neighbiy[0] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:LEFTIY').data().astype(np.int)
-    neighbiy[1] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:BOTTOMIY').data().astype(np.int)
-    neighbiy[2] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:RIGHTIY').data().astype(np.int)
-    neighbiy[3] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:TOPIY').data().astype(np.int)
+    neighbiy[0] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:LEFTIY').data().astype(int)
+    neighbiy[1] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:BOTTOMIY').data().astype(int)
+    neighbiy[2] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:RIGHTIY').data().astype(int)
+    neighbiy[3] = mds_connection.get(r'\SOLPS::TOP.SNAPSHOT.GRID:TOPIY').data().astype(int)
 
     neighbix[neighbix == r.shape[2]] = -1
     neighbiy[neighbiy == r.shape[1]] = -1

--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -179,18 +179,18 @@ def create_mesh_from_geom_data(geom_data):
     vol = geom_data['vol']
 
     # Loading neighbouring cell indices
-    neighbix = np.zeros(r.shape, dtype=np.int)
-    neighbiy = np.zeros(r.shape, dtype=np.int)
+    neighbix = np.zeros(r.shape, dtype=int)
+    neighbiy = np.zeros(r.shape, dtype=int)
 
-    neighbix[0] = geom_data['leftix'].astype(np.int)  # poloidal prev.
-    neighbix[1] = geom_data['bottomix'].astype(np.int)  # radial prev.
-    neighbix[2] = geom_data['rightix'].astype(np.int)  # poloidal next
-    neighbix[3] = geom_data['topix'].astype(np.int)  # radial next
+    neighbix[0] = geom_data['leftix'].astype(int)  # poloidal prev.
+    neighbix[1] = geom_data['bottomix'].astype(int)  # radial prev.
+    neighbix[2] = geom_data['rightix'].astype(int)  # poloidal next
+    neighbix[3] = geom_data['topix'].astype(int)  # radial next
 
-    neighbiy[0] = geom_data['leftiy'].astype(np.int)
-    neighbiy[1] = geom_data['bottomiy'].astype(np.int)
-    neighbiy[2] = geom_data['rightiy'].astype(np.int)
-    neighbiy[3] = geom_data['topiy'].astype(np.int)
+    neighbiy[0] = geom_data['leftiy'].astype(int)
+    neighbiy[1] = geom_data['bottomiy'].astype(int)
+    neighbiy[2] = geom_data['rightiy'].astype(int)
+    neighbiy[3] = geom_data['topiy'].astype(int)
 
     # In SOLPS cell indexing starts with -1 (guarding cell), but in SOLPSMesh -1 means no neighbour.
     neighbix += 1

--- a/cherab/solps/mesh_geometry.py
+++ b/cherab/solps/mesh_geometry.py
@@ -72,8 +72,8 @@ class SOLPSMesh:
 
         self._vol = vol
 
-        self._neighbix = neighbix.astype(np.int)
-        self._neighbiy = neighbiy.astype(np.int)
+        self._neighbix = neighbix.astype(int)
+        self._neighbiy = neighbiy.astype(int)
 
         self.vessel = None
 


### PR DESCRIPTION
Numpy 1.20 deprecated np.int, np.bool etc.
Python 3.8 now raises a SyntaxWarning when using is with literals.