### PR TITLE
Allow the user to specify individual paths to SOLPS raw ouput files in load_solps_from_raw_output()

### DIFF
--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -30,7 +30,7 @@ from cherab.solps.solps_plasma import SOLPSSimulation, prefer_element, eirene_fl
 
 
 # Code based on script by Felix Reimold (2016)
-def load_solps_from_raw_output(simulation_path, baserun_path=None, debug=False):
+def load_solps_from_raw_output(simulation_path, debug=False, baserun_path=None):
     """
     Load a SOLPS simulation from raw SOLPS output files.
 
@@ -42,8 +42,11 @@ def load_solps_from_raw_output(simulation_path, baserun_path=None, debug=False):
 
     :param str simulation_path: String path to simulation directory.
                                 Example: '/home/user/solps5/runs/simulation_name/run'.
+    :param bool debug: A flag for displaying textual debugging information when parsing
+                       the SOLPS files. Defaults to False.
     :param str baserun_path: Any files missing in the 'simulation_path' will be searched for
                              in 'baserun_path'. Defaults to 'simulation_path/../baserun' if None.
+
     :rtype: SOLPSSimulation
     """
 

--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -41,6 +41,7 @@ def load_solps_from_raw_output(simulation_path, debug=False):
     * Eirene output file (fort.44), optional
 
     :param str simulation_path: String path to simulation directory.
+                                Example: '/home/user/solps5/runs/simulation_name/run'.
     :rtype: SOLPSSimulation
     """
 
@@ -54,7 +55,9 @@ def load_solps_from_raw_output(simulation_path, debug=False):
 
     # Load SOLPS mesh geometry
     if not os.path.isfile(mesh_file_path):
-        raise RuntimeError("No B2 b2fgmtry file found in SOLPS output directory.")
+        mesh_file_path = os.path.join(simulation_path, '../baserun/b2fgmtry')
+        if not os.path.isfile(mesh_file_path):
+            raise RuntimeError("No B2 b2fgmtry file found in SOLPS output directory.")
     _, _, geom_data_dict = load_b2f_file(mesh_file_path, debug=debug)  # geom_data_dict is needed also for magnetic field
 
     if not os.path.isfile(b2_state_file):

--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -187,25 +187,6 @@ def load_solps_from_raw_output(simulation_path='', debug=False, mesh_file_path=N
     return sim
 
 
-def find_solps_file(simulation_path, baserun_path, filename):
-    """
-    Searches for a SOLPS output file in the current simulation and baserun directories.
-
-    Returns a path to the baserun version if the file is not found in the current simulation
-    directory.
-    Returns None if the file is not found anywhere.
-    """
-
-    solps_file = os.path.join(simulation_path, filename)
-    if not os.path.isfile(solps_file):
-        solps_file = os.path.join(baserun_path, filename)
-        if not os.path.isfile(solps_file):
-            return None
-        print("Warning! File {} is not found in {}.".format(filename, simulation_path),
-              "Will use the version from {}.".format(baserun_path))
-
-    return solps_file
-
 def create_mesh_from_geom_data(geom_data):
 
     r = geom_data['crx']

--- a/cherab/solps/formats/raw_simulation_files.py
+++ b/cherab/solps/formats/raw_simulation_files.py
@@ -42,6 +42,9 @@ def load_solps_from_raw_output(simulation_path, debug=False):
 
     :param str simulation_path: String path to simulation directory.
                                 Example: '/home/user/solps5/runs/simulation_name/run'.
+                                Note that 'b2fgmtry' will be searched for in
+                                'simulation_path/../baserun', if it is not found in
+                                'simulation_path'.
     :rtype: SOLPSSimulation
     """
 


### PR DESCRIPTION
~~This fixes #59 by adding `baserun_path` argument to `load_solps_from_raw_output()`. Now if the SOLPS file is not found in `simulation_path`, the version from `baserun_path` will be used.~~

This fixes #59 by adding `mesh_file_path`, `b2_state_file_path`, `b2_plasma_file_path` and `eirene_fort44_file_path` arguments to `load_solps_from_raw_output()`. Now the user can specify the path to any of the SOLPS output file, if this file is not in the `simulation_path` directory.