### PR TITLE
Fix an error in SOLPSSimulation.electron_velocities_cylindrical setter

### DIFF
--- a/cherab/solps/solps_plasma.py
+++ b/cherab/solps/solps_plasma.py
@@ -314,7 +314,7 @@ class SOLPSSimulation:
 
         # Converting to poloidal coordinates
         velocities = np.zeros(value.shape)
-        velocities[:, 2] = -value[:, 1]
+        velocities[2] = -value[1]
         velocities[:2] = self.mesh.to_poloidal(value[[0, 2]])
 
         self._electron_velocities_cylindrical = value

--- a/cherab/solps/tests/test_simulation.py
+++ b/cherab/solps/tests/test_simulation.py
@@ -13,54 +13,65 @@ class TestSOLPSSimulation(unittest.TestCase):
 
     def setUp(self):
         # Creating a test SOLPSMesh
-        rv = np.linspace(1., 2., 11)
-        zv = np.linspace(-1., 1., 21)
-        r2d, z2d = np.meshgrid(rv, zv, indexing='ij')
-        vol = (np.pi * (rv[1:] + rv[:-1]) * np.diff(rv))[:, None] * np.diff(zv)[None, :]
-        ny = rv.size - 1
-        nx = zv.size - 1
+        # closed magnetic surfaces only with circular cross section
+        r0 = 2.  # major radius
+        beta = np.linspace(0, 2 * np.pi, 19)  # poloidal angle
+        rho = np.linspace(0.5, 1., 6)  # magnetic surface radius
+        # cell vertices
+        r2d = r0 + rho[:, None] * np.cos(beta)[None, :]
+        z2d = rho[:, None] * np.sin(beta)[None, :]
+        # exact cell volume
+        vol = (np.pi * r0 * (rho[1:]**2 - rho[:-1]**2)[:, None] * (beta[1:] - beta[:-1])[None, :] +
+               2. / 3. * np.pi * (rho[1:]**3 - rho[:-1]**3)[:, None] * (np.sin(beta[1:]) - np.sin(beta[:-1]))[None, :])
+        ny = rho.size - 1
+        nx = beta.size - 1
         r = np.zeros((4, ny, nx))
         z = np.zeros((4, ny, nx))
         r[0] = r2d[:-1, :-1]
         z[0] = z2d[:-1, :-1]
-        r[1] = r2d[:-1, 1:]
-        z[1] = z2d[:-1, 1:]
-        r[2] = r2d[1:, :-1]
-        z[2] = z2d[1:, :-1]
-        r[3] = r2d[1:, 1:]
-        z[3] = z2d[1:, 1:]
+        r[1] = r2d[:-1, 1:]  # poloidal + 1
+        z[1] = z2d[:-1, 1:]  # poloidal + 1
+        r[2] = r2d[1:, :-1]  # radial + 1
+        z[2] = z2d[1:, :-1]  # radial + 1
+        r[3] = r2d[1:, 1:]  # poloidal + 1, radial + 1
+        z[3] = z2d[1:, 1:]  # poloidal + 1, radial + 1
         neighbix = -1 * np.ones((4, ny, nx), dtype=int)
-        neighbix[0, :, 1:] = np.arange(nx - 1, dtype=int)[None, :]
-        neighbix[1, 1:, :] = np.arange(nx, dtype=int)[None, :]
-        neighbix[1, :, :-1] = np.arange(1, nx, dtype=int)[None, :]
-        neighbix[1, :-1, :] = np.arange(nx, dtype=int)[None, :]
+        neighbix[0, 1:, :] = np.arange(nx, dtype=int)[None, :]  # left
+        neighbix[1, :, 1:] = np.arange(nx - 1, dtype=int)[None, :]  # bottom
+        neighbix[2, :-1, :] = np.arange(nx, dtype=int)[None, :]  # right
+        neighbix[3, :, :-1] = np.arange(1, nx, dtype=int)[None, :]  # top
+        neighbix[1, :, 0] = nx - 1  # closing the surfaces
+        neighbix[3, :, -1] = 0  # closing the surfaces
         neighbiy = -1 * np.ones((4, ny, nx), dtype=int)
-        neighbiy[0, :, 1:] = np.arange(ny, dtype=int)[:, None]
-        neighbiy[1, 1:, :] = np.arange(ny - 1, dtype=int)[:, None]
-        neighbiy[1, :, :-1] = np.arange(ny, dtype=int)[:, None]
-        neighbiy[1, :-1, :] = np.arange(1, ny, dtype=int)[:, None]
+        neighbiy[0, 1:, :] = np.arange(ny - 1, dtype=int)[:, None]  # left
+        neighbiy[1, :, :] = np.arange(ny, dtype=int)[:, None]  # bottom
+        neighbiy[2, :-1, :] = np.arange(1, ny, dtype=int)[:, None]  # right
+        neighbiy[3, :, :] = np.arange(ny, dtype=int)[:, None]  # top
         mesh = SOLPSMesh(r, z, vol, neighbix, neighbiy)
 
         # Creating a test SOLPSSimulation
         species_list = [('hydrogen', 0), ('hydrogen', 1)]
         self.sim = SOLPSSimulation(mesh, species_list)
         rng = default_rng()
-        self.sim.electron_temperature = 1.e3 + 1.e2 * rng.random((ny, nx))
-        self.sim.electron_density = 1.e19 + 1.e18 * rng.random((ny, nx))
+        b0 = 1.
+        b_field = np.zeros((3, ny, nx))
+        b_field[2] = b0 * r0 / (r0 + 0.5 * (rho[:-1] + rho[1:])[:, None] * np.cos(0.5 * (beta[:-1] + beta[1:]))[None, :])
+        b_field[0] = 0.01 * (rng.random((ny, nx)) - 0.5)
+        b_field[1] = 0.01 * (rng.random((ny, nx)) - 0.5)
+        self.sim.b_field = b_field
+        self.sim.electron_temperature = 1.e3 * (1 - (rho[:-1, None] - rho[0]) / (rho[-1] - rho[0])) + 1.e2 * (rng.random((ny, nx)) - 0.5)
+        self.sim.electron_density = 1.e19 * (1 - (rho[:-1, None] - rho[0]) / (rho[-1] - rho[0])) + 1.e18 * (rng.random((ny, nx)) - 0.5)
         electron_velocities = 1.e4 * rng.random((3, ny, nx))
         electron_velocities[2] += 1.e5
         self.sim.electron_velocities = electron_velocities
         self.sim.ion_temperature = self.sim.electron_temperature
         self.sim.neutral_temperature = 0.1 * self.sim.ion_temperature[None, :, :]
         self.sim.species_density = np.zeros((2, ny, nx))
-        self.sim.species_density[0] = 0.1 * self.sim.electron_density
+        self.sim.species_density[0] = 0.1 * self.sim.electron_density[::-1, :]
         self.sim.species_density[1] = self.sim.electron_density
         velocities = 1.e4 + rng.random((2, 3, ny, nx))
         velocities[1, 2] -= 1.e5
         self.sim.velocities = velocities
-        b_field = np.zeros((3, ny, nx))
-        b_field[2] = 1. + 0.1 * rng.random((ny, nx))
-        self.sim.b_field = b_field
 
     def test_vector_transform(self):
         """ Tests vector transforms (poloidal <--> cylindrical)"""
@@ -71,15 +82,15 @@ class TestSOLPSSimulation(unittest.TestCase):
         # this creates a new array at sim.b_field
         self.sim.b_field_cylindrical = self.sim.b_field_cylindrical
         # check if the new array is identical to the original one (poloidal --> cylindrical --> poloidal)
-        test_list.append(np.array_equiv(b_field, self.sim.b_field))
+        test_list.append(np.allclose(b_field, self.sim.b_field))
 
         electron_velocities = self.sim.electron_velocities
         self.sim.electron_velocities_cylindrical = self.sim.electron_velocities_cylindrical
-        test_list.append(np.array_equiv(electron_velocities, self.sim.electron_velocities))
+        test_list.append(np.allclose(electron_velocities, self.sim.electron_velocities))
 
         velocities = self.sim.velocities
         self.sim.velocities_cylindrical = self.sim.velocities_cylindrical
-        test_list.append(np.array_equiv(velocities, self.sim.velocities))
+        test_list.append(np.allclose(velocities, self.sim.velocities))
 
         return self.assertTrue(np.all(test_list))
 

--- a/cherab/solps/tests/test_simulation.py
+++ b/cherab/solps/tests/test_simulation.py
@@ -1,0 +1,88 @@
+import unittest
+
+import numpy as np
+from numpy.random import default_rng
+
+from cherab.solps import SOLPSMesh, SOLPSSimulation
+
+
+class TestSOLPSSimulation(unittest.TestCase):
+    """
+    Test SOLPSSimulation.
+    """
+
+    def setUp(self):
+        # Creating a test SOLPSMesh
+        rv = np.linspace(1., 2., 11)
+        zv = np.linspace(-1., 1., 21)
+        r2d, z2d = np.meshgrid(rv, zv, indexing='ij')
+        vol = (np.pi * (rv[1:] + rv[:-1]) * np.diff(rv))[:, None] * np.diff(zv)[None, :]
+        ny = rv.size - 1
+        nx = zv.size - 1
+        r = np.zeros((4, ny, nx))
+        z = np.zeros((4, ny, nx))
+        r[0] = r2d[:-1, :-1]
+        z[0] = z2d[:-1, :-1]
+        r[1] = r2d[:-1, 1:]
+        z[1] = z2d[:-1, 1:]
+        r[2] = r2d[1:, :-1]
+        z[2] = z2d[1:, :-1]
+        r[3] = r2d[1:, 1:]
+        z[3] = z2d[1:, 1:]
+        neighbix = -1 * np.ones((4, ny, nx), dtype=int)
+        neighbix[0, :, 1:] = np.arange(nx - 1, dtype=int)[None, :]
+        neighbix[1, 1:, :] = np.arange(nx, dtype=int)[None, :]
+        neighbix[1, :, :-1] = np.arange(1, nx, dtype=int)[None, :]
+        neighbix[1, :-1, :] = np.arange(nx, dtype=int)[None, :]
+        neighbiy = -1 * np.ones((4, ny, nx), dtype=int)
+        neighbiy[0, :, 1:] = np.arange(ny, dtype=int)[:, None]
+        neighbiy[1, 1:, :] = np.arange(ny - 1, dtype=int)[:, None]
+        neighbiy[1, :, :-1] = np.arange(ny, dtype=int)[:, None]
+        neighbiy[1, :-1, :] = np.arange(1, ny, dtype=int)[:, None]
+        mesh = SOLPSMesh(r, z, vol, neighbix, neighbiy)
+
+        # Creating a test SOLPSSimulation
+        species_list = [('hydrogen', 0), ('hydrogen', 1)]
+        self.sim = SOLPSSimulation(mesh, species_list)
+        rng = default_rng()
+        self.sim.electron_temperature = 1.e3 + 1.e2 * rng.random((ny, nx))
+        self.sim.electron_density = 1.e19 + 1.e18 * rng.random((ny, nx))
+        electron_velocities = 1.e4 * rng.random((3, ny, nx))
+        electron_velocities[2] += 1.e5
+        self.sim.electron_velocities = electron_velocities
+        self.sim.ion_temperature = self.sim.electron_temperature
+        self.sim.neutral_temperature = 0.1 * self.sim.ion_temperature[None, :, :]
+        self.sim.species_density = np.zeros((2, ny, nx))
+        self.sim.species_density[0] = 0.1 * self.sim.electron_density
+        self.sim.species_density[1] = self.sim.electron_density
+        velocities = 1.e4 + rng.random((2, 3, ny, nx))
+        velocities[1, 2] -= 1.e5
+        self.sim.velocities = velocities
+        b_field = np.zeros((3, ny, nx))
+        b_field[2] = 1. + 0.1 * rng.random((ny, nx))
+        self.sim.b_field = b_field
+
+    def test_vector_transform(self):
+        """ Tests vector transforms (poloidal <--> cylindrical)"""
+
+        test_list = []
+        # save a copy of sim.b_field
+        b_field = self.sim.b_field
+        # this creates a new array at sim.b_field
+        self.sim.b_field_cylindrical = self.sim.b_field_cylindrical
+        # check if the new array is identical to the original one (poloidal --> cylindrical --> poloidal)
+        test_list.append(np.array_equiv(b_field, self.sim.b_field))
+
+        electron_velocities = self.sim.electron_velocities
+        self.sim.electron_velocities_cylindrical = self.sim.electron_velocities_cylindrical
+        test_list.append(np.array_equiv(electron_velocities, self.sim.electron_velocities))
+
+        velocities = self.sim.velocities
+        self.sim.velocities_cylindrical = self.sim.velocities_cylindrical
+        test_list.append(np.array_equiv(velocities, self.sim.velocities))
+
+        return self.assertTrue(np.all(test_list))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cherab/solps/tests/test_simulation.py
+++ b/cherab/solps/tests/test_simulation.py
@@ -52,7 +52,7 @@ class TestSOLPSSimulation(unittest.TestCase):
         # Creating a test SOLPSSimulation
         species_list = [('hydrogen', 0), ('hydrogen', 1)]
         self.sim = SOLPSSimulation(mesh, species_list)
-        rng = default_rng()
+        rng = default_rng(seed=42)
         b0 = 1.
         b_field = np.zeros((3, ny, nx))
         b_field[2] = b0 * r0 / (r0 + 0.5 * (rho[:-1] + rho[1:])[:, None] * np.cos(0.5 * (beta[:-1] + beta[1:]))[None, :])
@@ -69,7 +69,7 @@ class TestSOLPSSimulation(unittest.TestCase):
         self.sim.species_density = np.zeros((2, ny, nx))
         self.sim.species_density[0] = 0.1 * self.sim.electron_density[::-1, :]
         self.sim.species_density[1] = self.sim.electron_density
-        velocities = 1.e4 + rng.random((2, 3, ny, nx))
+        velocities = 1.e4 * rng.random((2, 3, ny, nx))
         velocities[1, 2] -= 1.e5
         self.sim.velocities = velocities
 


### PR DESCRIPTION
This fixes #63 and adds a unit test for vector transforms from poloidal to cylindrical coordinates and vice versa performed in the `SOLPSSimulation` setters for the vector values.

Other unit tests can be added to `TestSOLPSSimulation` in the future.