### PR TITLE
Add Github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install cherab-solps and dependencies
+      run: python -m pip install -e .
+    - name: Run tests
+      run: dev/test.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cherab==1.3.0
 raysect==0.7.1
+cython==3.0a5


### PR DESCRIPTION
Pretty basic for now: builds the package and runs the few tests which already exist. This should provide a useful base for when we add more tests.

The build procedure for this package is slightly different to core. Just running `python setup.py build-ext` led to the tests failing in a fresh venv on my local machine because `cherab.solps` was not detected as being installed. Installing using `pip install -e .` did work, and matches what is suggested in the README.