### PR TITLE
Add support for Cherab 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Project Changelog
 =================
 
+Release 1.2.1 (TBD)
+-------------------
+
+* Added support for Cherab 1.4.
+* Update `generomak_raw_files_solps_line_emitter.py` demo to use the new group observer from Cherab 1.4.
+
 Release 1.2.0 (31 Dec 2021)
 ----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.14", "cython==3.0a5", "raysect==0.7.1", "cherab==1.3"]
+requires = ["setuptools", "wheel", "numpy>=1.14", "cython==3.0a5", "raysect==0.7.1", "cherab==1.4"]
 build-backend="setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cherab==1.3.0
+cherab==1.4.0
 raysect==0.7.1
 cython==3.0a5

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("README.md") as f:
 
 setup(
     name="cherab-solps",
-    version="1.2.0",
+    version="1.2.1",
     license="EUPL 1.1",
     namespace_packages=['cherab'],
     description="Cherab spectroscopy framework: SOLPS submodule",
@@ -63,6 +63,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["raysect==0.7.1", "cherab==1.3"],
+    install_requires=["raysect==0.7.1", "cherab==1.4"],
     ext_modules=cythonize(extensions, force=force, compiler_directives=cython_directives),
 )


### PR DESCRIPTION
This fixes #69 by making the `generomak_raw_files_solps_line_emitter.py` demo to use the generalised group observers from Cherab 1.4 and updating the setup files to support Cherab 1.4.

@jacklovell, look like that Cython 3.0a5 is incompatible with Python 3.10, which means we may not be able to provide the wheel for 3.10. @sean-kosslow wrote to me on Slack that he couldn't install `cherab-edge2d` on Python 3.10 and the best I could suggest is to install both the core and submodule in development mode with Cython 0.29.33.