### PR TITLE
Update the building from source instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,13 @@ pip install cherab-solps
 This module depends on the core Cherab framework.
 Cherab core, and all of its dependencies, are available on PyPI and can be installed using `pip`.
 
-Note also that a [bug](https://github.com/cython/cython/issues/2918) in Cython prevents Cherab submodules from installing correctly.
-This bug is fixed, but not yet released in the stable version of Cython.
-As a result, you will need to install a pre-release version of Cython before installing this package.
 Recent versions of `pip` which support [PEP 518](https://www.python.org/dev/peps/pep-0518/) will handle this automatically when you run `pip install cherab-solps` and a binary wheel is not available for your platform or Python version.
 
 For older versions of `pip` you may need to manually install the build-time dependencies.
 First, clone this repository, then do:
 
 ```bash
-pip install -U cython==3.0a5
-pip install cherab
+pip install -r <path-to-cherab-solps>/requirements.txt
 pip install <path-to-cherab-solps>
 ```
 


### PR DESCRIPTION
This PR removes the reference to Cython 3.0a in `README.md`, as the stable version of Cython 3 is now used. Also, the required dependencies can be installed from `requirements.txt`, so that is also reflected.